### PR TITLE
Fix two bugs (`xs`, `Source`)

### DIFF
--- a/content/needs/exp/quadrant.md
+++ b/content/needs/exp/quadrant.md
@@ -62,7 +62,7 @@ In _Evaluating Project Decisions_, a team faced performance problems after adopt
 ---
 
 ## Impact of Project Time on Customer–Developer Views
-xs
+
 ![Quadrant - Time Impact](<quad_time.png>)
 
 *Source: Hoover et al., Evaluating Project Decisions*

--- a/content/needs/exp/tos.md
+++ b/content/needs/exp/tos.md
@@ -72,11 +72,5 @@ Thresholds should be **unambiguous** and stated as clear requirements in each ar
 
 ---
 
-## Sources
-
-- Hoover, Carol L., Mel Rosso-Llopart, and Gil Taran, _Evaluating Project Decisions: Case Studies in Software Engineering_. Addison-Wesley Professional, 2010. ISBN-13: 978‐0321544568. [O'Reilly Media](https://www.oreilly.com/library/view/evaluating-project-decisions/9780321685629/)
-
----
-
 {: .highlight }
 **Disclaimer:** AI is used for text summarization, explaining, and formatting. Authors have verified all facts and claims. In case of an error, feel free to file an issue.


### PR DESCRIPTION
- Remove `xs` redundant text
- Remove redundant `Source` section for Tartan TOS