### PR TITLE
Fix bug: Move 'Easy' to Outcome-oriented column

### DIFF
--- a/content/scope/wbs/orient.md
+++ b/content/scope/wbs/orient.md
@@ -390,7 +390,7 @@ flowchart TB
 | **Drop Chapter 2 – impact on total cost?**    | **Easy**         | Medium             | Medium              |
 | **Which chapter is more expensive (2 vs 3)?** | **Easy**         | Medium             | Medium              |
 | **Add a new chapter – what changes?**         | **Easy**         | Medium             | Medium              |
-| **Chapter 3 has heavy illustrations – where does that work live?** | Medium | **Easy** | Medium |
+| **Chapter 3 has heavy illustrations – where does that work live?** | **Easy** | Medium | Medium |
 
 > Takeaway: **Outcome orientation best answers scope & sponsor questions.**  
 > **Discipline** best answers staffing/ownership.  


### PR DESCRIPTION
Scope -> WBS -> orientation -> In the last row of the table "Which WBS answers which questions fast?", the "Easy" rating was incorrectly placed under "Discipline-oriented". It should be under "Outcome-oriented".